### PR TITLE
fix(security): move secret key to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 # Created by https://www.toptal.com/developers/gitignore/api/django
 # Edit at https://www.toptal.com/developers/gitignore?templates=django
 
+
+### Privates ###
+
+config.py
+
 ### Django ###
 *.log
 *.pot

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 
 
 ### Privates ###
-
 config.py
 
 ### Django ###

--- a/web_project/settings.py
+++ b/web_project/settings.py
@@ -19,9 +19,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-y#qo&bm29lnsa_uzima_i*!6ivu@htr_@zv54o=zefk3r3brgk'
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 


### PR DESCRIPTION
## Description

Shift exposed `SECRET_KEY` from [`web_project/settings.py`](https://github.com/niji-co/Fusion-Server/blob/main/web_project/settings.py#L23) to `config.py` _(hidden, on application root layer)_

> Looking through the source code, `SECRET_KEY` is not referenced any where at the moment. Everything should be working fine, but just to be sure can one of the reviewers help test it.

Resolves #5 